### PR TITLE
fix: show up to 100 images in "bilderstrecke"

### DIFF
--- a/pages/bilder/_id.vue
+++ b/pages/bilder/_id.vue
@@ -48,7 +48,7 @@ export default {
         bilderstrecke(where: {id: $id}) {
           id
           titel
-          bilder {
+          bilder(first: 100) {
             id
             width
             url


### PR DESCRIPTION
According to the documentation of HyGraph, there is a default limit for graphql queries that fetch multiple *related* entries. In our case, one "bilderstrecke" is fetching multiple "bilder". Before this change, it was fetching only up to 10 images.

![image](https://user-images.githubusercontent.com/2110676/211663187-7d827e94-3597-45d4-868f-7641f0d8665d.png)

